### PR TITLE
修复冒号分隔的mac地址无法唤醒的bug

### DIFF
--- a/src/wol.go
+++ b/src/wol.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"regexp"
+	"strings"
 )
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -104,6 +105,8 @@ func ipFromInterface(iface string) (*net.UDPAddr, error) {
 
 // wake 执行唤醒指令
 func Wake(macAddr string, ip string, port string) error {
+	macAddr = strings.ReplaceAll(macAddr, ":", "-")
+	macAddr = strings.ReplaceAll(macAddr, "：", "-")
 	bcastInterface := ""
 	bcastAddr := fmt.Sprintf("%s:%s", ip, port)
 	udpAddr, err := net.ResolveUDPAddr("udp", bcastAddr)


### PR DESCRIPTION
感谢作者的辛勤工作。今天部署的时候发现怎么也唤醒不了，后来发现是我在路由器复制的mac地址是冒号分隔的，换用-分隔就可以正常唤醒，于是简单修改了一下代码，防止后面用的人踩坑。